### PR TITLE
Define equality of MCState

### DIFF
--- a/Chapter2/missionaries.py
+++ b/Chapter2/missionaries.py
@@ -42,7 +42,7 @@ class MCState:
     def __hash__(self) -> int:
         state: int = self.wm * MAX_NUM**3 + self.wc * MAX_NUM**2 + self.em * MAX_NUM + self.ec
         state *= 1 if self.boat else -1
-        return state
+        return hash(state)
         
     def goal_test(self) -> bool:
         return self.is_legal and self.em == MAX_NUM and self.ec == MAX_NUM

--- a/Chapter2/missionaries.py
+++ b/Chapter2/missionaries.py
@@ -39,10 +39,10 @@ class MCState:
                (self.em == other.em) and (self.ec == other.ec) and \
                (self.boat == other.boat)
     
-    def __hash__(self):
-        state: int = self.wm * 1000 + self.wc * 100 + self.em * 10 + self.ec
+    def __hash__(self) -> int:
+        state: int = self.wm * MAX_NUM**3 + self.wc * MAX_NUM**2 + self.em * MAX_NUM + self.ec
         state *= 1 if self.boat else -1
-        return hash(state)
+        return state
         
     def goal_test(self) -> bool:
         return self.is_legal and self.em == MAX_NUM and self.ec == MAX_NUM

--- a/Chapter2/missionaries.py
+++ b/Chapter2/missionaries.py
@@ -34,6 +34,16 @@ class MCState:
                 "The boat is on the {} bank.")\
             .format(self.wm, self.wc, self.em, self.ec, ("west" if self.boat else "east"))
 
+    def __eq__(self, other) -> bool:
+        return (self.wm == other.wm) and (self.wc == other.wc) and \
+               (self.em == other.em) and (self.ec == other.ec) and \
+               (self.boat == other.boat)
+    
+    def __hash__(self):
+        state: int = self.wm * 1000 + self.wc * 100 + self.em * 10 + self.ec
+        state *= 1 if self.boat else -1
+        return hash(state)
+        
     def goal_test(self) -> bool:
         return self.is_legal and self.em == MAX_NUM and self.ec == MAX_NUM
 

--- a/Chapter2/missionaries.py
+++ b/Chapter2/missionaries.py
@@ -40,7 +40,7 @@ class MCState:
                (self.boat == other.boat)
     
     def __hash__(self) -> int:
-        state: int = self.wm * MAX_NUM**3 + self.wc * MAX_NUM**2 + self.em * MAX_NUM + self.ec
+        state: int = self.wm * (MAX_NUM + 1)**3 + self.wc * (MAX_NUM + 1)**2 + self.em * (MAX_NUM + 1) + self.ec
         state *= 1 if self.boat else -1
         return hash(state)
         


### PR DESCRIPTION
While debugging `missionaries.py`, I discovered that the `explored` set accumulates duplicate `MCState`s.

To solve this problem, I've overridden the `__eq__` and `__hash__` of the `MCState`. 

This patch resolves the issue [#22]